### PR TITLE
Fixing priority bug with go-messagearea

### DIFF
--- a/components/class-go-messagearea.php
+++ b/components/class-go-messagearea.php
@@ -105,6 +105,9 @@ class GO_Messagearea
 			return isset( $this->messages[ $priority ] ) ? $this->messages[ $priority ] : array();
 		}//end if
 
+		// let's make sure the priorities are ordered appropriately
+		ksort( $this->messages );
+
 		return $this->messages;
 	}//end get
 


### PR DESCRIPTION
Details on the issue can be found here: https://github.com/GigaOM/go-messagearea/issues/9

Thanks for drawing our attention to the bug, @pcrumm!
